### PR TITLE
Fix overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,18 @@
             padding: 2rem;
             margin-bottom: 3rem;
             box-shadow: 0 8px 25px rgba(180, 148, 246, 0.15);
+            position: relative; /* allow overlay positioning */
+            overflow: hidden; /* hide CrazyGames links */
+        }
+
+        .hide-overlay {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 40px; /* approximate height of CrazyGames banner */
+            background: #1a1a1a;
+            pointer-events: none;
         }
 
         .game-frame {
@@ -349,12 +361,13 @@
             </section>
 
             <section class="game-container">
-                <iframe 
+                <iframe
                     src="https://games.crazygames.com/en_US/piece-of-cake-merge-and-bake/index.html"
                     class="game-frame"
                     allowfullscreen
                     title="Piece of Cake - Merge and Bake Game">
                 </iframe>
+                <div class="hide-overlay"></div>
             </section>
 
             <section class="content-section">

--- a/index.html
+++ b/index.html
@@ -115,9 +115,10 @@
             bottom: 0;
             left: 0;
             width: 100%;
-            height: 40px; /* approximate height of CrazyGames banner */
+            height: 60px; /* approximate height of CrazyGames banner */
             background: #1a1a1a;
             pointer-events: none;
+            z-index: 10;
         }
 
         .game-frame {

--- a/piece_of_cake_game_site.html
+++ b/piece_of_cake_game_site.html
@@ -115,9 +115,10 @@
             bottom: 0;
             left: 0;
             width: 100%;
-            height: 40px;
+            height: 60px;
             background: #1a1a1a;
             pointer-events: none;
+            z-index: 10;
         }
 
         .game-frame {

--- a/piece_of_cake_game_site.html
+++ b/piece_of_cake_game_site.html
@@ -106,6 +106,18 @@
             padding: 2rem;
             margin-bottom: 3rem;
             box-shadow: 0 8px 25px rgba(180, 148, 246, 0.15);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .hide-overlay {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 40px;
+            background: #1a1a1a;
+            pointer-events: none;
         }
 
         .game-frame {
@@ -349,12 +361,13 @@
             </section>
 
             <section class="game-container">
-                <iframe 
+                <iframe
                     src="https://games.crazygames.com/en_US/piece-of-cake-merge-and-bake/index.html"
                     class="game-frame"
                     allowfullscreen
                     title="Piece of Cake - Merge and Bake Game">
                 </iframe>
+                <div class="hide-overlay"></div>
             </section>
 
             <section class="content-section">


### PR DESCRIPTION
## Summary
- hide CrazyGames banner overlay under the game iframe

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684dab193e24833385deeeb75ed553a6